### PR TITLE
Add maxBuffer option

### DIFF
--- a/tasks/bg-shell.coffee
+++ b/tasks/bg-shell.coffee
@@ -58,6 +58,7 @@ module.exports = (grunt)->
     else
       failOnError
 
+
     childProcess = exec(config.cmd, config.execOpts, (err, stdout, stderr) ->
       config.done(err, stdout, stderr);
       stderrHandler err if err


### PR DESCRIPTION
Certain processes with heavy logging were exceeding the maxBuffer and causing the process to be killed. This provides an option to increase the maxBuffer when necessary.
