### PR TITLE
Add the ability to specify a function for the command.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -20,5 +20,8 @@ module.exports = (grunt) ->
           cmd: 'ls -la'
           bg: false
 
+        testFunction:
+          cmd: -> 'ls'
+
 
   grunt.registerTask 'default', 'bgShell'

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ bgShell: {
   }     
 }
 ```
-* ```cmd```: command to execute
+* ```cmd```: command to execute or ```function(){}``` that returns a command to execute
 * ```execOpts```: options for 
   [```child_process.exec```](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)
 * ```stdout```: ```true```, ```false``` or ```function(out){}```

--- a/tasks/bg-shell.coffee
+++ b/tasks/bg-shell.coffee
@@ -57,8 +57,12 @@ module.exports = (grunt)->
     else
       failOnError
 
+    command = if _.isFunction(config.cmd)
+      config.cmd()
+    else
+      config.cmd
 
-    childProcess = exec(config.cmd, config.execOpts, (err, stdout, stderr) ->
+    childProcess = exec(command, config.execOpts, (err, stdout, stderr) ->
       config.done(err, stdout, stderr);
       stderrHandler err if err
       taskDone()


### PR DESCRIPTION
Users are now able to specify either a command to execute or a function that returns a command to execute. This is useful if the command to execute is state dependent. Previously, users would have to specify a command that acted as a wrapper.
