### PR TITLE
Configure child process to run with parent's stdin

### DIFF
--- a/tasks/child-process.coffee
+++ b/tasks/child-process.coffee
@@ -30,6 +30,7 @@ exports.execCmd = (command, options, callback)->
   child = spawn(file, args,
     cwd: options.cwd
     env: options.env
+    stdio: [process.stdin]
     windowsVerbatimArguments: !!options.windowsVerbatimArguments
   )
 


### PR DESCRIPTION
Changed how child processes are spawned so that interactive commands work as expected.
