### PR TITLE
Prevent inadvertent template compilation

### DIFF
--- a/tasks/bg-shell.coffee
+++ b/tasks/bg-shell.coffee
@@ -17,7 +17,7 @@ module.exports = (grunt)->
     done: noop
 
   grunt.registerMultiTask 'bgShell', 'Run shell commands', ->
-    config = _.defaults @data, grunt.config.get('bgShell')._defaults, defaults
+    config = _.defaults @data, grunt.config.getRaw('bgShell')._defaults, defaults
 
     command = config.cmd
     command = command() if _.isFunction(command)


### PR DESCRIPTION
This call is just to fetch the `_defaults` object, and we do not need
parsed templates here.
Because of this, we cannot have template strings on other targets.

For example, if I have config something like this:
```
bgShell:{
  install:{
    cmd: 'npm install',
    bg: true
  },
  compile:{
    cmd: 'mv binary folder/<%=buildEnv.folder%>'
  }
}
```

In the config above `buildEnv` may not be available when we run the `install` target, it might be injected later from another task using `grunt.option.set()` before we run the `compile` target.
In this case, the `install` target does not run, because `grunt.option.get` tries to compile the template string, and fails.